### PR TITLE
Revert "Writing the conf atomically to allow use in parallel environments."

### DIFF
--- a/friendly/settings.py
+++ b/friendly/settings.py
@@ -3,7 +3,6 @@
 import configparser
 import os
 import sys
-from tempfile import NamedTemporaryFile
 
 from friendly_traceback import debug_helper
 from friendly_traceback.config import session
@@ -43,26 +42,14 @@ ENVIRONMENT = terminal_type
 # create settings directories and files
 
 
-def config_atomic_write(config: configparser.ConfigParser) -> None:
-    """Atomically write a ConfigParser instance to FILENAME.
-
-    Without a way to write the config atomically, we could write
-    garbage on the config file, rendering it unparsable.
-    """
-    with NamedTemporaryFile(
-        dir=os.path.dirname(FILENAME), delete=False, mode="w", encoding="UTF-8"
-    ) as tmpfile:
-        config.write(tmpfile)
-    os.rename(tmpfile.name, FILENAME)
-
-
 def ensure_existence():
     """Ensures that a settings file exists"""
     if not os.path.exists(config_dir):
         os.makedirs(config_dir)
     if not os.path.exists(FILENAME):
         config = configparser.ConfigParser()
-        config_atomic_write(config)
+        with open(FILENAME, "w") as config_file:
+            config.write(config_file)
 
 
 try:
@@ -116,7 +103,8 @@ def write(*, option="unknown", value="unknown", environment=None):
     if not config.has_section(section):
         config.add_section(section)
     config[section][option] = value
-    config_atomic_write(config)
+    with open(FILENAME, "w") as config_file:
+        config.write(config_file)
 
 
 def _remove_environment(environment=None):
@@ -133,7 +121,8 @@ def _remove_environment(environment=None):
     config = configparser.ConfigParser()
     config.read(FILENAME)
     config.remove_section(section)
-    config_atomic_write(config)
+    with open(FILENAME, "w") as config_file:
+        config.write(config_file)
 
 
 def has_environment(environment=None):


### PR DESCRIPTION
Reverts friendly-traceback/friendly#25

It creates problems when I run it locally.