### PR TITLE
Avoid using `getdefaultlocale()`

### DIFF
--- a/friendly/settings.py
+++ b/friendly/settings.py
@@ -149,5 +149,5 @@ def print_settings():
 def get_lang() -> str:
     lang = read(option="lang", environment="common")
     if lang is None:
-        lang = locale.getdefaultlocale()[0]
+        lang = locale.getlocale()[0]
     return lang


### PR DESCRIPTION
It is deprecated since Python 3.11 and will be removed in 3.13: see https://bugs.python.org/issue46659 and
https://docs.python.org/3.11/library/locale.html#locale.getdefaultlocale

On Python 3.11, just importing friendly produces a rather annoying warning

```
>>> import friendly
`DeprecationWarning`: Use setlocale(), getencoding() and getlocale() instead
```